### PR TITLE
Correct filename in #include directive

### DIFF
--- a/ArduCor/ArduCor.cpp
+++ b/ArduCor/ArduCor.cpp
@@ -13,7 +13,7 @@
  */
 
 #include "ArduCor.h"
-#include "ColorPresets.h"
+#include "Palettes.h"
 
 // Default brightness of LEDS, must be a value between 0 and 100.
 const uint8_t  DEFAULT_BRIGHTNESS  = 50;


### PR DESCRIPTION
ColorPresets.h was renamed to Palettes.h in aae6ee83df01b382cae442ee493e2b3a8ef44af3 but the `#include` directive was not updated to reflect this change. This caused compilation to fail:
```
ArduCor.cpp:16:26: fatal error: ColorPresets.h: No such file or directory
```

Fixes https://github.com/timsee/ArduCor/issues/1
CC: @sammie72